### PR TITLE
Add Minter.transferCollection to mitiage failing safeMintRange

### DIFF
--- a/src/Minter.sol
+++ b/src/Minter.sol
@@ -27,4 +27,9 @@ contract Minter is Ownable {
     }
     b.transferOwnership(nextOwner);
   }
+
+  function transferCollection(address collection, address nextOwner) external onlyOwner {
+    Balot b = Balot(collection);
+    b.transferOwnership(nextOwner);
+  }
 }

--- a/src/Minter.t.sol
+++ b/src/Minter.t.sol
@@ -105,4 +105,10 @@ contract MinterTest is Test, ERC721Holder {
 
     assertEq(balot.owner(), address(nextOwner));
   }
+
+  function testTransferCollection() public {
+    balot.transferOwnership(address(minter));
+    minter.transferCollection(address(balot), address(this));
+    assertEq(balot.owner(), address(this));
+  }
 }

--- a/test/testMinter.js
+++ b/test/testMinter.js
@@ -119,7 +119,7 @@ describe("Balot", async () => {
       // 1. Deploy Minter
       minter = await Minter.deploy();
 
-      // 2. Tranfer Balot ownership to minter
+      // 2. Transfer Balot ownership to minter
       await balot.transferOwnership(minter.address);
 
       const start = 1,

--- a/test/testMinter.js
+++ b/test/testMinter.js
@@ -99,4 +99,49 @@ describe("Balot", async () => {
       ).to.be.revertedWith("Ownable: caller is not the owner");
     });
   });
+
+  describe("Failing Minter.safeMintRange", async () => {
+    let minter, minterOwner, nextOwner, recipient;
+
+    beforeEach(async () => {
+      [
+        ,
+        minterOwner,
+        nextOwner,
+        recipient,
+        attacker,
+        attackerNextOwner,
+        attackerRecipient,
+      ] = await ethers.getSigners();
+
+      const Minter = await ethers.getContractFactory("Minter", minterOwner);
+
+      // 1. Deploy Minter
+      minter = await Minter.deploy();
+
+      // 2. Tranfer Balot ownership to minter
+      await balot.transferOwnership(minter.address);
+
+      const start = 1,
+        end = 9999;
+      // 3. Range mint + transfer Balot ownership
+      await expect(
+        minter.safeMintRange(
+          balot.address,
+          nextOwner.address,
+          recipient.address,
+          start,
+          end
+        )
+      ).to.be.revertedWith(
+        "Transaction reverted: contract call run out of gas and made the transaction revert"
+      );
+    });
+
+    it("should still be transferrable", async () => {
+      minter.transferCollection(balot.address, owner.address);
+
+      expect(await balot.owner()).to.be.equal(owner.address);
+    });
+  });
 });


### PR DESCRIPTION
I have introduced a Javascript test on top of a Solidity test. While a bit redundant, I couldn't figure a way to test a failing call to `safeMintRange` with Solidity.

Fix https://github.com/whitecube-online/balot/issues/35