### PR TITLE
Add Minter.transferCollection to mitiage failing safeMintRange

### DIFF
--- a/src/Minter.sol
+++ b/src/Minter.sol
@@ -27,4 +27,9 @@ contract Minter is Ownable {
     }
     b.transferOwnership(nextOwner);
   }
+
+  function transferCollection(address collection, address nextOwner) external onlyOwner {
+    Balot b = Balot(collection);
+    b.transferOwnership(nextOwner);
+  }
 }

--- a/src/Minter.t.sol
+++ b/src/Minter.t.sol
@@ -17,6 +17,11 @@ contract MockCaller {
     Minter minter = Minter(collection);
     minter.safeMintRange(collection, msg.sender, msg.sender, start, end);
   }
+
+  function callTransferCollection(address collection, address nextOwner) public {
+    Minter minter = Minter(collection);
+    minter.transferCollection(collection, nextOwner);
+  }
 }
 
 
@@ -104,5 +109,22 @@ contract MinterTest is Test, ERC721Holder {
     balot.tokenURI(301);
 
     assertEq(balot.owner(), address(nextOwner));
+  }
+
+  function testTransferCollection() public {
+    balot.transferOwnership(address(minter));
+    minter.transferCollection(address(balot), address(this));
+    
+    assertEq(balot.owner(), address(this));
+  }
+
+  function testUnauthorizedTransferCollection() public {
+    balot.transferOwnership(address(minter));
+    address nextOwner = address(this);
+
+    vm.expectRevert();
+    mc.callTransferCollection(
+      address(balot), nextOwner
+    );
   }
 }

--- a/test/testMinter.js
+++ b/test/testMinter.js
@@ -99,4 +99,49 @@ describe("Balot", async () => {
       ).to.be.revertedWith("Ownable: caller is not the owner");
     });
   });
+
+  describe("Failing Minter.safeMintRange", async () => {
+    let minter, minterOwner, nextOwner, recipient;
+
+    beforeEach(async () => {
+      [
+        ,
+        minterOwner,
+        nextOwner,
+        recipient,
+        attacker,
+        attackerNextOwner,
+        attackerRecipient,
+      ] = await ethers.getSigners();
+
+      const Minter = await ethers.getContractFactory("Minter", minterOwner);
+
+      // 1. Deploy Minter
+      minter = await Minter.deploy();
+
+      // 2. Tranfer Balot ownership to minter
+      await balot.transferOwnership(minter.address);
+
+      const start = 1,
+        end = 9999;
+      // 3. Range mint + transfer Balot ownership
+      await expect(
+        minter.safeMintRange(
+          balot.address,
+          nextOwner.address,
+          recipient.address,
+          start,
+          end
+        )
+      ).to.be.revertedWith(
+        "Transaction reverted: contract call run out of gas and made the transaction revert"
+      );
+    });
+
+    it("should still be transferrable", async () => {
+      await minter.transferCollection(balot.address, owner.address);
+
+      expect(await balot.owner()).to.be.equal(owner.address);
+    });
+  });
 });


### PR DESCRIPTION
Replaces #38 

Update: added `testUnauthorizedTransferCollection`.