### PR TITLE
Test scenarios with mainnet fork

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-[*.{js,yml,sol,json,cpp,cc,h,html,md,sh}]
+[*.{js,ts,yml,sol,json,cpp,cc,h,html,md,sh}]
 indent_style = space
 indent_size = 2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
   check-hardhat:
     name: Hardhat project
     runs-on: ubuntu-latest
+    environment: test
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,6 @@ jobs:
   check-hardhat:
     name: Hardhat project
     runs-on: ubuntu-latest
-    environment: test
     steps:
       - uses: actions/checkout@v3
         with:
@@ -41,3 +40,5 @@ jobs:
 
       - name: Run test
         run: npx hardhat test
+        env:
+          ARCHIVE_NODE_API: ${{ secrets.ARCHIVE_NODE_API}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,10 @@ jobs:
       - name: Install HartHat
         run: npm ci --dev
 
-      - name: Run test
-        run: npx hardhat test
+      - name: Run contract interaction tests
+        run: npx hardhat test test/testMinter.ts
+
+      - name: Run scenarios tests
+        run: npx hardhat test test/testScenarios.ts
         env:
           ARCHIVE_NODE_API: ${{ secrets.ARCHIVE_NODE_API}}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ artifacts/
 
 #Hardhat plugin files
 typechain-types/
+
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@types/mocha": "^9.1.1",
         "@types/node": "^17.0.35",
         "chai": "^4.3.6",
+        "dotenv": "^16.0.1",
         "hardhat": "^2.9.6",
         "hardhat-preprocessor": "^0.1.4",
         "ts-node": "^10.8.0",
@@ -2836,6 +2837,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ecc-jsbn": {
@@ -19094,6 +19104,12 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true
+    },
+    "dotenv": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
       "dev": true
     },
     "ecc-jsbn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,13 @@
         "@types/chai": "^4.3.1",
         "@types/mocha": "^9.1.1",
         "@types/node": "^17.0.35",
-        "chai": "^4.3.6",
+        "chai": "4.3.6",
         "dotenv": "^16.0.1",
+        "ethers": "5.6.8",
         "hardhat": "^2.9.6",
         "hardhat-preprocessor": "^0.1.4",
         "ts-node": "^10.8.0",
+        "typechain": "8.0.0",
         "typescript": "^4.7.2"
       }
     },
@@ -82,7 +84,7 @@
     "node_modules/@ensdomains/ens/node_modules/decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -92,7 +94,7 @@
     "node_modules/@ensdomains/ens/node_modules/fs-extra": {
       "version": "0.30.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-      "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+      "integrity": "sha512-UvSPKyhMn6LEd/WpUaV9C9t3zATuqoqfWc3QdPhPLb58prN9tqYPlPWi8Krxi44loBoUzlobqZ3+8tGpxxSzwA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -113,7 +115,7 @@
     "node_modules/@ensdomains/ens/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -126,7 +128,7 @@
     "node_modules/@ensdomains/ens/node_modules/jsonfile": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
       "dev": true,
       "peer": true,
       "optionalDependencies": {
@@ -343,7 +345,7 @@
     "node_modules/@ethereum-waffle/compiler/node_modules/find-replace": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
-      "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
+      "integrity": "sha512-KrUnjzDCD9426YnCP56zGYy/eieTnhtK6Vn++j+JJzmlsWWwEkDnsyVF575spT6HJ6Ow9tlbT3TQTDsa+O4UWA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -370,11 +372,24 @@
     "node_modules/@ethereum-waffle/compiler/node_modules/jsonfile": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
       "dev": true,
       "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@ethereum-waffle/compiler/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/@ethereum-waffle/compiler/node_modules/semver": {
@@ -413,7 +428,7 @@
     "node_modules/@ethereum-waffle/compiler/node_modules/solc/node_modules/fs-extra": {
       "version": "0.30.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-      "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+      "integrity": "sha512-UvSPKyhMn6LEd/WpUaV9C9t3zATuqoqfWc3QdPhPLb58prN9tqYPlPWi8Krxi44loBoUzlobqZ3+8tGpxxSzwA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -719,7 +734,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/properties": "^5.6.0"
@@ -799,7 +813,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.6.3",
         "@ethersproject/abstract-provider": "^5.6.1",
@@ -854,7 +867,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.6.2",
         "@ethersproject/basex": "^5.6.1",
@@ -885,7 +897,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.6.2",
         "@ethersproject/address": "^5.6.1",
@@ -972,7 +983,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/sha2": "^5.6.1"
@@ -1012,7 +1022,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.6.1",
         "@ethersproject/abstract-signer": "^5.6.2",
@@ -1041,7 +1050,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -1073,7 +1081,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/logger": "^5.6.0"
@@ -1114,7 +1121,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/logger": "^5.6.0",
@@ -1160,7 +1166,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.6.2",
         "@ethersproject/bytes": "^5.6.1",
@@ -1233,7 +1238,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.6.2",
         "@ethersproject/constants": "^5.6.1",
@@ -1255,7 +1259,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.6.1",
         "@ethersproject/abstract-signer": "^5.6.2",
@@ -1312,7 +1315,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/hash": "^5.6.1",
@@ -1801,11 +1803,10 @@
       }
     },
     "node_modules/@types/prettier": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.1.tgz",
-      "integrity": "sha512-XFjFHmaLVifrAKaZ+EKghFHtHSUonyw8P2Qmy2/+osBnrKbH9UYtlK10zg8/kCt47MFilll/DEDKy3DHfJ0URw==",
-      "dev": true,
-      "peer": true
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
+      "integrity": "sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==",
+      "dev": true
     },
     "node_modules/@types/resolve": {
       "version": "0.0.8",
@@ -1942,8 +1943,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
       "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -2068,7 +2068,6 @@
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
       "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2209,8 +2208,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -2547,7 +2545,6 @@
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
       "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-back": "^3.1.0",
         "find-replace": "^3.0.0",
@@ -2563,7 +2560,6 @@
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
       "integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-back": "^4.0.2",
         "chalk": "^2.4.2",
@@ -2579,7 +2575,6 @@
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
       "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2589,7 +2584,6 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
       "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2721,7 +2715,7 @@
     "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -2777,7 +2771,6 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -2814,7 +2807,7 @@
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -2851,7 +2844,7 @@
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -2971,7 +2964,7 @@
     "node_modules/eth-ens-namehash": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
-      "integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
+      "integrity": "sha512-VWEI1+KJfz4Km//dadyvBBoBeSQ0MHTXPvr8UIXiLW6IanxvAV+DmlZAijZwAyggqGUfwQBeHf7tc9wzc1piSw==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -2982,7 +2975,7 @@
     "node_modules/eth-ens-namehash/node_modules/js-sha3": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+      "integrity": "sha512-GII20kjaPX0zJ8wzkTbNDYMY7msuZcTWk8S5UOh6806Jq/wz1J8/bnr8uGU0DAUmYDjj2Mr4X1cW8v/GLYnR+g==",
       "dev": true,
       "peer": true
     },
@@ -3110,7 +3103,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "5.6.3",
         "@ethersproject/abstract-provider": "5.6.1",
@@ -3147,7 +3139,7 @@
     "node_modules/ethjs-unit": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
-      "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
+      "integrity": "sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -3209,7 +3201,7 @@
     "node_modules/extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
       "dev": true,
       "engines": [
         "node >=0.6.0"
@@ -3247,7 +3239,6 @@
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
       "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-back": "^3.0.1"
       },
@@ -3318,7 +3309,7 @@
     "node_modules/forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -13506,7 +13497,7 @@
     "node_modules/getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -13563,7 +13554,7 @@
     "node_modules/har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -13765,7 +13756,7 @@
     "node_modules/http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -13885,7 +13876,7 @@
     "node_modules/invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -13904,7 +13895,7 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "peer": true
     },
@@ -14010,7 +14001,7 @@
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true,
       "peer": true
     },
@@ -14036,7 +14027,7 @@
     "node_modules/is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
       "dev": true,
       "peer": true
     },
@@ -14062,7 +14053,7 @@
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "dev": true,
       "peer": true
     },
@@ -14087,7 +14078,7 @@
     "node_modules/jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "dev": true,
       "peer": true
     },
@@ -14108,7 +14099,7 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true,
       "peer": true
     },
@@ -14174,7 +14165,7 @@
     "node_modules/lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -14302,7 +14293,7 @@
     "node_modules/load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "integrity": "sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -14338,16 +14329,15 @@
     "node_modules/lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
       "dev": true,
       "peer": true
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -14641,16 +14631,15 @@
       "peer": true
     },
     "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true,
-      "peer": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mnemonist": {
@@ -14970,7 +14959,7 @@
     "node_modules/number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -14980,7 +14969,7 @@
     "node_modules/number-to-bn": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
-      "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+      "integrity": "sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -15053,7 +15042,7 @@
     "node_modules/os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -15123,7 +15112,7 @@
     "node_modules/parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -15209,7 +15198,7 @@
     "node_modules/path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -15225,7 +15214,7 @@
     "node_modules/path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "integrity": "sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -15265,7 +15254,7 @@
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
       "dev": true,
       "peer": true
     },
@@ -15284,7 +15273,7 @@
     "node_modules/pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -15294,7 +15283,7 @@
     "node_modules/pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -15304,7 +15293,7 @@
     "node_modules/pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -15327,7 +15316,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
       "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -15354,7 +15342,7 @@
     "node_modules/punycode": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+      "integrity": "sha512-Yxz2kRwT90aPiWEMHVYnEf4+rhwF1tBmmZ4KepCP+Wkium9JxtWnUm1nqGwpiAHr/tnTSeHqr3wb++jgSkXjhA==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -15379,7 +15367,7 @@
     "node_modules/querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
       "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "dev": true,
       "peer": true,
@@ -15443,7 +15431,7 @@
     "node_modules/read-pkg-up/node_modules/find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -15457,7 +15445,7 @@
     "node_modules/read-pkg-up/node_modules/path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "integrity": "sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -15498,7 +15486,6 @@
       "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
       "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -15986,8 +15973,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-format/-/string-format-2.0.0.tgz",
       "integrity": "sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -16070,7 +16056,6 @@
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
       "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-back": "^4.0.1",
         "deep-extend": "~0.6.0",
@@ -16086,7 +16071,6 @@
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
       "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -16096,7 +16080,6 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
       "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -16218,7 +16201,6 @@
       "resolved": "https://registry.npmjs.org/ts-command-line-args/-/ts-command-line-args-2.3.1.tgz",
       "integrity": "sha512-FR3y7pLl/fuUNSmnPhfLArGqRrpojQgIEEOVzYx9DhTmfIN7C9RWSfpkJEF4J+Gk7aVx5pak8I7vWZsaN4N84g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.0",
         "command-line-args": "^5.1.1",
@@ -16234,7 +16216,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -16250,7 +16231,6 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -16267,7 +16247,6 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -16279,15 +16258,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/ts-command-line-args/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -16297,7 +16274,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -16333,6 +16309,19 @@
       },
       "bin": {
         "ts-generator": "dist/cli/run.js"
+      }
+    },
+    "node_modules/ts-generator/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/ts-generator/node_modules/ts-essentials": {
@@ -16457,7 +16446,6 @@
       "resolved": "https://registry.npmjs.org/typechain/-/typechain-8.0.0.tgz",
       "integrity": "sha512-rqDfDYc9voVAhmfVfAwzg3VYFvhvs5ck1X9T/iWkX745Cul4t+V/smjnyqrbDzWDbzD93xfld1epg7Y/uFAesQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/prettier": "^2.1.1",
         "debug": "^4.3.1",
@@ -16482,7 +16470,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -16496,19 +16483,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/typechain/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/typescript": {
@@ -16529,7 +16503,6 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
       "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -16585,7 +16558,7 @@
     "node_modules/url/node_modules/punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
       "dev": true,
       "peer": true
     },
@@ -16727,7 +16700,6 @@
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
       "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "reduce-flatten": "^2.0.0",
         "typical": "^5.2.0"
@@ -16741,7 +16713,6 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
       "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -16970,14 +16941,14 @@
         "decamelize": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
           "dev": true,
           "peer": true
         },
         "fs-extra": {
           "version": "0.30.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+          "integrity": "sha512-UvSPKyhMn6LEd/WpUaV9C9t3zATuqoqfWc3QdPhPLb58prN9tqYPlPWi8Krxi44loBoUzlobqZ3+8tGpxxSzwA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -16998,7 +16969,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -17008,7 +16979,7 @@
         "jsonfile": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -17192,7 +17163,7 @@
         "find-replace": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
-          "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
+          "integrity": "sha512-KrUnjzDCD9426YnCP56zGYy/eieTnhtK6Vn++j+JJzmlsWWwEkDnsyVF575spT6HJ6Ow9tlbT3TQTDsa+O4UWA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -17215,11 +17186,21 @@
         "jsonfile": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
           "dev": true,
           "peer": true,
           "requires": {
             "graceful-fs": "^4.1.6"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "minimist": "^1.2.6"
           }
         },
         "semver": {
@@ -17249,7 +17230,7 @@
             "fs-extra": {
               "version": "0.30.0",
               "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-              "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+              "integrity": "sha512-UvSPKyhMn6LEd/WpUaV9C9t3zATuqoqfWc3QdPhPLb58prN9tqYPlPWi8Krxi44loBoUzlobqZ3+8tGpxxSzwA==",
               "dev": true,
               "peer": true,
               "requires": {
@@ -17485,7 +17466,6 @@
       "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.6.1.tgz",
       "integrity": "sha512-a52MkVz4vuBXR06nvflPMotld1FJWSj2QT0985v7P/emPZO00PucFAkbcmq2vpVU7Ts7umKiSI6SppiLykVWsA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/properties": "^5.6.0"
@@ -17525,7 +17505,6 @@
       "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.6.2.tgz",
       "integrity": "sha512-hguUA57BIKi6WY0kHvZp6PwPlWF87MCeB4B7Z7AbUpTxfFXFdn/3b0GmjZPagIHS+3yhcBJDnuEfU4Xz+Ks/8g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@ethersproject/abi": "^5.6.3",
         "@ethersproject/abstract-provider": "^5.6.1",
@@ -17560,7 +17539,6 @@
       "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.6.2.tgz",
       "integrity": "sha512-tERxW8Ccf9CxW2db3WsN01Qao3wFeRsfYY9TCuhmG0xNpl2IO8wgXU3HtWIZ49gUWPggRy4Yg5axU0ACaEKf1Q==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@ethersproject/abstract-signer": "^5.6.2",
         "@ethersproject/basex": "^5.6.1",
@@ -17581,7 +17559,6 @@
       "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.6.1.tgz",
       "integrity": "sha512-KfyJ6Zwz3kGeX25nLihPwZYlDqamO6pfGKNnVMWWfEVVp42lTfCZVXXy5Ie8IZTN0HKwAngpIPi7gk4IJzgmqQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@ethersproject/abstract-signer": "^5.6.2",
         "@ethersproject/address": "^5.6.1",
@@ -17628,7 +17605,6 @@
       "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.6.1.tgz",
       "integrity": "sha512-k4gRQ+D93zDRPNUfmduNKq065uadC2YjMP/CqwwX5qG6R05f47boq6pLZtV/RnC4NZAYOPH1Cyo54q0c9sshRQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/sha2": "^5.6.1"
@@ -17648,7 +17624,6 @@
       "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.6.8.tgz",
       "integrity": "sha512-Wf+CseT/iOJjrGtAOf3ck9zS7AgPmr2fZ3N97r4+YXN3mBePTG2/bJ8DApl9mVwYL+RpYbNxMEkEp4mPGdwG/w==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@ethersproject/abstract-provider": "^5.6.1",
         "@ethersproject/abstract-signer": "^5.6.2",
@@ -17677,7 +17652,6 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
           "dev": true,
-          "peer": true,
           "requires": {}
         }
       }
@@ -17687,7 +17661,6 @@
       "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.6.1.tgz",
       "integrity": "sha512-/wtPNHwbmng+5yi3fkipA8YBT59DdkGRoC2vWk09Dci/q5DlgnMkhIycjHlavrvrjJBkFjO/ueLyT+aUDfc4lA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/logger": "^5.6.0"
@@ -17708,7 +17681,6 @@
       "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.6.1.tgz",
       "integrity": "sha512-5K2GyqcW7G4Yo3uenHegbXRPDgARpWUiXc6RiF7b6i/HXUoWlb7uCARh7BAHg7/qT/Q5ydofNwiZcim9qpjB6g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/logger": "^5.6.0",
@@ -17734,7 +17706,6 @@
       "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.6.1.tgz",
       "integrity": "sha512-KWqVLkUUoLBfL1iwdzUVlkNqAUIFMpbbeH0rgCfKmJp0vFtY4AsaN91gHKo9ZZLkC4UOm3cI3BmMV4N53BOq4g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@ethersproject/bignumber": "^5.6.2",
         "@ethersproject/bytes": "^5.6.1",
@@ -17777,7 +17748,6 @@
       "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.6.1.tgz",
       "integrity": "sha512-rEfSEvMQ7obcx3KWD5EWWx77gqv54K6BKiZzKxkQJqtpriVsICrktIQmKl8ReNToPeIYPnFHpXvKpi068YFZXw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@ethersproject/bignumber": "^5.6.2",
         "@ethersproject/constants": "^5.6.1",
@@ -17789,7 +17759,6 @@
       "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.6.2.tgz",
       "integrity": "sha512-lrgh0FDQPuOnHcF80Q3gHYsSUODp6aJLAdDmDV0xKCN/T7D99ta1jGVhulg3PY8wiXEngD0DfM0I2XKXlrqJfg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@ethersproject/abstract-provider": "^5.6.1",
         "@ethersproject/abstract-signer": "^5.6.2",
@@ -17826,7 +17795,6 @@
       "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.6.1.tgz",
       "integrity": "sha512-wiPRgBpNbNwCQFoCr8bcWO8o5I810cqO6mkdtKfLKFlLxeCWcnzDi4Alu8iyNzlhYuS9npCwivMbRWF19dyblw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/hash": "^5.6.1",
@@ -18267,11 +18235,10 @@
       }
     },
     "@types/prettier": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.1.tgz",
-      "integrity": "sha512-XFjFHmaLVifrAKaZ+EKghFHtHSUonyw8P2Qmy2/+osBnrKbH9UYtlK10zg8/kCt47MFilll/DEDKy3DHfJ0URw==",
-      "dev": true,
-      "peer": true
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
+      "integrity": "sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==",
+      "dev": true
     },
     "@types/resolve": {
       "version": "0.0.8",
@@ -18390,8 +18357,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
       "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "agent-base": {
       "version": "6.0.2",
@@ -18487,8 +18453,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
       "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "asn1": {
       "version": "0.2.6",
@@ -18602,8 +18567,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -18881,7 +18845,6 @@
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
       "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "array-back": "^3.1.0",
         "find-replace": "^3.0.0",
@@ -18894,7 +18857,6 @@
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
       "integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "array-back": "^4.0.2",
         "chalk": "^2.4.2",
@@ -18906,15 +18868,13 @@
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
           "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
-          "dev": true,
-          "peer": true
+          "dev": true
         },
         "typical": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
           "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -19024,7 +18984,7 @@
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -19059,8 +19019,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "deferred-leveldown": {
       "version": "5.3.0",
@@ -19090,7 +19049,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
       "peer": true
     },
@@ -19115,7 +19074,7 @@
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -19219,7 +19178,7 @@
     "eth-ens-namehash": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
-      "integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
+      "integrity": "sha512-VWEI1+KJfz4Km//dadyvBBoBeSQ0MHTXPvr8UIXiLW6IanxvAV+DmlZAijZwAyggqGUfwQBeHf7tc9wzc1piSw==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -19230,7 +19189,7 @@
         "js-sha3": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+          "integrity": "sha512-GII20kjaPX0zJ8wzkTbNDYMY7msuZcTWk8S5UOh6806Jq/wz1J8/bnr8uGU0DAUmYDjj2Mr4X1cW8v/GLYnR+g==",
           "dev": true,
           "peer": true
         }
@@ -19343,7 +19302,6 @@
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.8.tgz",
       "integrity": "sha512-YxIGaltAOdvBFPZwIkyHnXbW40f1r8mHUgapW6dxkO+6t7H6wY8POUn0Kbxrd/N7I4hHxyi7YCddMAH/wmho2w==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@ethersproject/abi": "5.6.3",
         "@ethersproject/abstract-provider": "5.6.1",
@@ -19380,7 +19338,7 @@
     "ethjs-unit": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
-      "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
+      "integrity": "sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -19433,7 +19391,7 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
       "dev": true,
       "peer": true
     },
@@ -19465,7 +19423,6 @@
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
       "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "array-back": "^3.0.1"
       }
@@ -19513,7 +19470,7 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
       "dev": true,
       "peer": true
     },
@@ -27549,7 +27506,7 @@
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -27594,7 +27551,7 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
       "dev": true,
       "peer": true
     },
@@ -27756,7 +27713,7 @@
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -27843,7 +27800,7 @@
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
       "dev": true,
       "peer": true
     },
@@ -27859,7 +27816,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "peer": true
     },
@@ -27931,7 +27888,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true,
       "peer": true
     },
@@ -27951,7 +27908,7 @@
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
       "dev": true,
       "peer": true
     },
@@ -27974,7 +27931,7 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "dev": true,
       "peer": true
     },
@@ -27996,7 +27953,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "dev": true,
       "peer": true
     },
@@ -28017,7 +27974,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true,
       "peer": true
     },
@@ -28076,7 +28033,7 @@
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -28174,7 +28131,7 @@
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "integrity": "sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -28204,16 +28161,15 @@
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
       "dev": true,
       "peer": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true
     },
     "log-symbols": {
       "version": "4.1.0",
@@ -28459,14 +28415,10 @@
       "peer": true
     },
     "mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "minimist": "^1.2.6"
-      }
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true
     },
     "mnemonist": {
       "version": "0.38.5",
@@ -28696,14 +28648,14 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
       "dev": true,
       "peer": true
     },
     "number-to-bn": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
-      "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+      "integrity": "sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -28762,7 +28714,7 @@
     "os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -28811,7 +28763,7 @@
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -28878,7 +28830,7 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
       "dev": true,
       "peer": true
     },
@@ -28891,7 +28843,7 @@
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "integrity": "sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -28922,7 +28874,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
       "dev": true,
       "peer": true
     },
@@ -28935,21 +28887,21 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "dev": true,
       "peer": true
     },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
       "dev": true,
       "peer": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -28967,8 +28919,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
       "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "prr": {
       "version": "1.0.1",
@@ -28986,7 +28937,7 @@
     "punycode": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+      "integrity": "sha512-Yxz2kRwT90aPiWEMHVYnEf4+rhwF1tBmmZ4KepCP+Wkium9JxtWnUm1nqGwpiAHr/tnTSeHqr3wb++jgSkXjhA==",
       "dev": true,
       "peer": true
     },
@@ -29002,7 +28953,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
       "dev": true,
       "peer": true
     },
@@ -29053,7 +29004,7 @@
         "find-up": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -29064,7 +29015,7 @@
         "path-exists": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "integrity": "sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==",
           "dev": true,
           "peer": true,
           "requires": {
@@ -29097,8 +29048,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
       "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "request": {
       "version": "2.88.2",
@@ -29494,8 +29444,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-format/-/string-format-2.0.0.tgz",
       "integrity": "sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "string-width": {
       "version": "4.2.3",
@@ -29556,7 +29505,6 @@
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
       "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
       "dev": true,
-      "peer": true,
       "requires": {
         "array-back": "^4.0.1",
         "deep-extend": "~0.6.0",
@@ -29568,15 +29516,13 @@
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
           "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
-          "dev": true,
-          "peer": true
+          "dev": true
         },
         "typical": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
           "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -29679,7 +29625,6 @@
       "resolved": "https://registry.npmjs.org/ts-command-line-args/-/ts-command-line-args-2.3.1.tgz",
       "integrity": "sha512-FR3y7pLl/fuUNSmnPhfLArGqRrpojQgIEEOVzYx9DhTmfIN7C9RWSfpkJEF4J+Gk7aVx5pak8I7vWZsaN4N84g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "chalk": "^4.1.0",
         "command-line-args": "^5.1.1",
@@ -29692,7 +29637,6 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
-          "peer": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -29702,7 +29646,6 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
-          "peer": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -29713,7 +29656,6 @@
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
-          "peer": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -29722,22 +29664,19 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "peer": true
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "peer": true
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
-          "peer": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -29769,6 +29708,16 @@
         "ts-essentials": "^1.0.0"
       },
       "dependencies": {
+        "mkdirp": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "minimist": "^1.2.6"
+          }
+        },
         "ts-essentials": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-1.0.4.tgz",
@@ -29858,7 +29807,6 @@
       "resolved": "https://registry.npmjs.org/typechain/-/typechain-8.0.0.tgz",
       "integrity": "sha512-rqDfDYc9voVAhmfVfAwzg3VYFvhvs5ck1X9T/iWkX745Cul4t+V/smjnyqrbDzWDbzD93xfld1epg7Y/uFAesQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@types/prettier": "^2.1.1",
         "debug": "^4.3.1",
@@ -29877,7 +29825,6 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
           "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
           "dev": true,
-          "peer": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -29886,13 +29833,6 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
-        },
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true,
-          "peer": true
         }
       }
     },
@@ -29906,8 +29846,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
       "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "undici": {
       "version": "4.16.0",
@@ -29951,7 +29890,7 @@
         "punycode": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
           "dev": true,
           "peer": true
         }
@@ -30076,7 +30015,6 @@
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
       "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "reduce-flatten": "^2.0.0",
         "typical": "^5.2.0"
@@ -30086,8 +30024,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
           "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,17 +1,19 @@
 {
   "devDependencies": {
-    "@nomiclabs/hardhat-ethers": "^2.0.6",
-    "@nomiclabs/hardhat-waffle": "^2.0.3",
-    "@typechain/ethers-v5": "^10.0.0",
-    "@typechain/hardhat": "^6.0.0",
-    "@types/chai": "^4.3.1",
-    "@types/mocha": "^9.1.1",
-    "@types/node": "^17.0.35",
-    "chai": "^4.3.6",
-    "dotenv": "^16.0.1",
-    "hardhat": "^2.9.6",
-    "hardhat-preprocessor": "^0.1.4",
-    "ts-node": "^10.8.0",
-    "typescript": "^4.7.2"
+    "@nomiclabs/hardhat-ethers": "2.0.6",
+    "@nomiclabs/hardhat-waffle": "2.0.3",
+    "@typechain/ethers-v5": "10.0.0",
+    "@typechain/hardhat": "6.0.0",
+    "@types/chai": "4.3.1",
+    "@types/mocha": "9.1.1",
+    "@types/node": "17.0.35",
+    "chai": "4.3.6",
+    "dotenv": "16.0.1",
+    "ethers": "5.6.8",
+    "hardhat": "2.9.6",
+    "hardhat-preprocessor": "0.1.4",
+    "ts-node": "10.8.0",
+    "typechain": "8.0.0",
+    "typescript": "4.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@types/mocha": "^9.1.1",
     "@types/node": "^17.0.35",
     "chai": "^4.3.6",
+    "dotenv": "^16.0.1",
     "hardhat": "^2.9.6",
     "hardhat-preprocessor": "^0.1.4",
     "ts-node": "^10.8.0",

--- a/test/testMinter.ts
+++ b/test/testMinter.ts
@@ -1,11 +1,14 @@
-const { expect } = require("chai");
-const { ethers } = require("hardhat");
-const { beforeEach } = require("mocha");
+import { expect } from "chai";
+import { beforeEach } from "mocha";
+
+import { Contract } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { ethers } from "hardhat";
 
 const baseUri = "https://example.com/";
 
 describe("Balot", async () => {
-  let balot, owner;
+  let balot: Contract, owner: SignerWithAddress;
 
   beforeEach(async () => {
     [owner] = await ethers.getSigners();
@@ -30,7 +33,10 @@ describe("Balot", async () => {
   });
 
   describe("Minter.safeMintRange in order", async () => {
-    let minter, minterOwner, nextOwner, recipient;
+    let minter: Contract,
+      minterOwner: SignerWithAddress,
+      nextOwner: SignerWithAddress,
+      recipient: SignerWithAddress;
 
     beforeEach(async () => {
       [, minterOwner, nextOwner, recipient] = await ethers.getSigners();
@@ -61,18 +67,15 @@ describe("Balot", async () => {
   });
 
   describe("Minter.safeMintRange by attacker", async () => {
-    let minter, minterOwner, nextOwner, recipient;
+    let minter: Contract,
+      minterOwner: SignerWithAddress,
+      attacker: SignerWithAddress,
+      attackerNextOwner: SignerWithAddress,
+      attackerRecipient: SignerWithAddress;
 
     beforeEach(async () => {
-      [
-        ,
-        minterOwner,
-        nextOwner,
-        recipient,
-        attacker,
-        attackerNextOwner,
-        attackerRecipient,
-      ] = await ethers.getSigners();
+      [, minterOwner, attacker, attackerNextOwner, attackerRecipient] =
+        await ethers.getSigners();
 
       const Minter = await ethers.getContractFactory("Minter", minterOwner);
 
@@ -101,18 +104,13 @@ describe("Balot", async () => {
   });
 
   describe("Failing Minter.safeMintRange", async () => {
-    let minter, minterOwner, nextOwner, recipient;
+    let minter: Contract,
+      minterOwner: SignerWithAddress,
+      nextOwner: SignerWithAddress,
+      recipient: SignerWithAddress;
 
     beforeEach(async () => {
-      [
-        ,
-        minterOwner,
-        nextOwner,
-        recipient,
-        attacker,
-        attackerNextOwner,
-        attackerRecipient,
-      ] = await ethers.getSigners();
+      [, minterOwner, nextOwner, recipient] = await ethers.getSigners();
 
       const Minter = await ethers.getContractFactory("Minter", minterOwner);
 

--- a/test/testMinter.ts
+++ b/test/testMinter.ts
@@ -46,7 +46,7 @@ describe("Balot", async () => {
       // 1. Deploy Minter
       minter = await Minter.deploy();
 
-      // 2. Tranfer Balot ownership to minter
+      // 2. Transfer Balot ownership to minter
       await balot.transferOwnership(minter.address);
 
       const start = 1,
@@ -117,7 +117,7 @@ describe("Balot", async () => {
       // 1. Deploy Minter
       minter = await Minter.deploy();
 
-      // 2. Tranfer Balot ownership to minter
+      // 2. Transfer Balot ownership to minter
       await balot.transferOwnership(minter.address);
 
       const start = 1,

--- a/test/testScenarios.js
+++ b/test/testScenarios.js
@@ -1,0 +1,167 @@
+const { expect } = require("chai");
+const { ethers, network } = require("hardhat");
+const { before, beforeEach } = require("mocha");
+const fs = require("fs");
+
+const dotenv = require("dotenv");
+const { min } = require("bn.js");
+dotenv.config();
+
+const BALOT_ABI = JSON.parse(
+  fs.readFileSync(__dirname + "/../assets/Balot.abi")
+);
+
+const ADDRESSES = {
+  balot: "0x6b877dfaf74b22913a494d1fc95d7e30c2b88ea1",
+  safe: "0xf078544e774faf5d10dd04c43f443a80c917c49c",
+};
+
+describe("All good scenario", async () => {
+  let minterOwner, minter, balotFromSafe, initialSafeBalance;
+
+  before(async () => {
+    await network.provider.request({
+      method: "hardhat_reset",
+      params: [
+        {
+          forking: {
+            jsonRpcUrl: `${process.env.ARCHIVE_NODE_API}`,
+            blockNumber: 14878670,
+          },
+        },
+      ],
+    });
+
+    // Give ETH to safe to allow it to perform calls
+    await network.provider.send("hardhat_setBalance", [
+      ADDRESSES.safe,
+      "0x10000000000000000",
+    ]);
+    await network.provider.request({
+      method: "hardhat_impersonateAccount",
+      params: [ADDRESSES.safe],
+    });
+  });
+  after(async () => {
+    await network.provider.request({
+      method: "hardhat_stopImpersonatingAccount",
+      params: [ADDRESSES.safe],
+    });
+  });
+
+  it("Step 1/3: deploy minter", async () => {
+    [minterOwner] = await ethers.getSigners();
+
+    const Minter = await ethers.getContractFactory("Minter", minterOwner);
+    minter = await Minter.deploy();
+  });
+
+  it("Step 2/3: transfer Balot ownership", async () => {
+    const safeSigner = await ethers.getSigner(ADDRESSES.safe);
+    balotFromSafe = new ethers.Contract(ADDRESSES.balot, BALOT_ABI, safeSigner);
+
+    initialSafeBalance = parseInt(
+      await balotFromSafe.balanceOf(ADDRESSES.safe)
+    );
+
+    await balotFromSafe.transferOwnership(minter.address);
+
+    expect((await balotFromSafe.owner()).toUpperCase()).to.equal(
+      minter.address.toUpperCase()
+    );
+  });
+
+  it("Step 3/3: safe mint range", async () => {
+    await minter.safeMintRange(
+      ADDRESSES.balot,
+      ADDRESSES.safe,
+      ADDRESSES.safe,
+      1,
+      300
+    );
+
+    const newSafeBalance = parseInt(
+      await balotFromSafe.balanceOf(ADDRESSES.safe)
+    );
+    expect(newSafeBalance).to.equal(initialSafeBalance + 300);
+    expect((await balotFromSafe.owner()).toUpperCase()).to.equal(
+      ADDRESSES.safe.toUpperCase()
+    );
+  });
+});
+
+describe("Failing mint & reverting scenario", async () => {
+  let minterOwner, minter, balotFromSafe;
+
+  before(async () => {
+    await network.provider.request({
+      method: "hardhat_reset",
+      params: [
+        {
+          forking: {
+            jsonRpcUrl: `${process.env.ARCHIVE_NODE_API}`,
+            blockNumber: 14878670,
+          },
+        },
+      ],
+    });
+
+    // Give ETH to safe to allow it to perform calls
+    await network.provider.send("hardhat_setBalance", [
+      ADDRESSES.safe,
+      "0x10000000000000000",
+    ]);
+    await network.provider.request({
+      method: "hardhat_impersonateAccount",
+      params: [ADDRESSES.safe],
+    });
+  });
+  after(async () => {
+    await network.provider.request({
+      method: "hardhat_stopImpersonatingAccount",
+      params: [ADDRESSES.safe],
+    });
+  });
+
+  it("Step 1/4: deploy minter", async () => {
+    [minterOwner] = await ethers.getSigners();
+
+    const Minter = await ethers.getContractFactory("Minter", minterOwner);
+    minter = await Minter.deploy();
+  });
+
+  it("Step 2/4: transfer Balot ownership", async () => {
+    const safeSigner = await ethers.getSigner(ADDRESSES.safe);
+    balotFromSafe = new ethers.Contract(ADDRESSES.balot, BALOT_ABI, safeSigner);
+
+    initialSafeBalance = parseInt(
+      await balotFromSafe.balanceOf(ADDRESSES.safe)
+    );
+
+    await balotFromSafe.transferOwnership(minter.address);
+
+    expect((await balotFromSafe.owner()).toUpperCase()).to.equal(
+      minter.address.toUpperCase()
+    );
+  });
+  it("Step 3/4: safe mint range FAILED", async () => {
+    await expect(
+      minter.safeMintRange(
+        ADDRESSES.balot,
+        ADDRESSES.safe,
+        ADDRESSES.safe,
+        1,
+        1000
+      )
+    ).to.be.revertedWith(
+      "Transaction reverted: contract call run out of gas and made the transaction revert"
+    );
+  });
+  it("Step 4/4: transfer Balot ownership back to Safe", async () => {
+    await minter.transferCollection(ADDRESSES.balot, ADDRESSES.safe);
+
+    expect((await balotFromSafe.owner()).toUpperCase()).to.equal(
+      ADDRESSES.safe.toUpperCase()
+    );
+  });
+});

--- a/test/testScenarios.ts
+++ b/test/testScenarios.ts
@@ -19,7 +19,9 @@ const ADDRESSES = {
   safe: "0xf078544e774faf5d10dd04c43f443a80c917c49c",
 };
 
-describe("All good scenario", async () => {
+describe("All good scenario", async function () {
+  this.timeout(2 * 60 * 1000);
+
   let minterOwner: SignerWithAddress,
     minter: Contract,
     balotFromSafe: Contract,
@@ -109,7 +111,9 @@ describe("All good scenario", async () => {
   });
 });
 
-describe("Failing mint & reverting scenario", async () => {
+describe("Failing mint & reverting scenario", async function () {
+  this.timeout(2 * 60 * 1000);
+
   let minterOwner: SignerWithAddress, minter: Contract, balotFromSafe: Contract;
 
   before(async () => {

--- a/test/testScenarios.ts
+++ b/test/testScenarios.ts
@@ -43,13 +43,13 @@ describe("All good scenario", async () => {
       ADDRESSES.safe,
       "0x10000000000000000",
     ]);
-    await network.provider.request({
+    return await network.provider.request({
       method: "hardhat_impersonateAccount",
       params: [ADDRESSES.safe],
     });
   });
   after(async () => {
-    await network.provider.request({
+    return await network.provider.request({
       method: "hardhat_stopImpersonatingAccount",
       params: [ADDRESSES.safe],
     });
@@ -66,6 +66,7 @@ describe("All good scenario", async () => {
         (await minter.deployTransaction.wait()).gasUsed
       }`
     );
+    return;
   });
 
   it("Step 2/3: transfer Balot ownership", async () => {
@@ -81,6 +82,7 @@ describe("All good scenario", async () => {
     expect((await balotFromSafe.owner()).toUpperCase()).to.equal(
       minter.address.toUpperCase()
     );
+    return;
   });
 
   it("Step 3/3: safe mint range", async () => {
@@ -103,6 +105,7 @@ describe("All good scenario", async () => {
     console.debug(
       `SafeMintRange gas used: ${(await safeMintRangeTx.wait()).gasUsed}`
     );
+    return;
   });
 });
 
@@ -127,13 +130,13 @@ describe("Failing mint & reverting scenario", async () => {
       ADDRESSES.safe,
       "0x10000000000000000",
     ]);
-    await network.provider.request({
+    return await network.provider.request({
       method: "hardhat_impersonateAccount",
       params: [ADDRESSES.safe],
     });
   });
   after(async () => {
-    await network.provider.request({
+    return await network.provider.request({
       method: "hardhat_stopImpersonatingAccount",
       params: [ADDRESSES.safe],
     });
@@ -150,6 +153,7 @@ describe("Failing mint & reverting scenario", async () => {
         (await minter.deployTransaction.wait()).gasUsed
       }`
     );
+    return;
   });
 
   it("Step 2/4: transfer Balot ownership", async () => {
@@ -158,12 +162,13 @@ describe("Failing mint & reverting scenario", async () => {
 
     await balotFromSafe.transferOwnership(minter.address);
 
-    expect((await balotFromSafe.owner()).toUpperCase()).to.equal(
+    await expect((await balotFromSafe.owner()).toUpperCase()).to.equal(
       minter.address.toUpperCase()
     );
+    return;
   });
   it("Step 3/4: safe mint range FAILED", async () => {
-    await expect(
+    return await expect(
       minter.safeMintRange(
         ADDRESSES.balot,
         ADDRESSES.safe,
@@ -190,5 +195,6 @@ describe("Failing mint & reverting scenario", async () => {
         (await transferCollectionTx.wait()).gasUsed
       }`
     );
+    return;
   });
 });


### PR DESCRIPTION
For tests to run, the `ARCHIVE_NODE_API` environment variable must be setup to an archive node (eg. `https://eth-mainnet.alchemyapi.io/v2/<key>`). The block used is fixed to a mainnet block that happened some hours ago (May 31st 2022).

We could also test these steps by hand by doing the following:

- run the local hardhat fork with `npx hardhat node --fork https://eth-mainnet.alchemyapi.io/v2/<key> --fork-block-number 14878670`
- import the first displayed private key in a local metamask, plugged via RPC to `http://127.0.0.1:8545/`
- deploy the Minter
- run a metamask script (task) running the `hardhat_setBalance` and `hardhat_impersonateAccount` commands that we're using in tests
- transfer ownership of Balot to Minter
- run `hardhat_stopImpersonatingAccount`
- run `Minter.safeMintRange()` and observe results.