### PR TITLE
Remove `transferOwnership` from range mint function

### DIFF
--- a/src/Minter.sol
+++ b/src/Minter.sol
@@ -13,7 +13,6 @@ interface Balot {
 contract Minter is Ownable {
   function safeMintRange(
     address collection,
-    address nextOwner,
     address to,
     uint16 start,
     uint16 end
@@ -25,7 +24,6 @@ contract Minter is Ownable {
         ".json"
       )));
     }
-    b.transferOwnership(nextOwner);
   }
 
   function transferCollection(address collection, address nextOwner) external onlyOwner {

--- a/src/Minter.t.sol
+++ b/src/Minter.t.sol
@@ -8,14 +8,13 @@ import {Balot} from "./Balot.sol";
 import {Minter} from "./Minter.sol";
 
 contract MockCaller {
-
   function callSafeMintRangeToSelf(
     address collection,
     uint16 start,
     uint16 end
   ) public {
     Minter minter = Minter(collection);
-    minter.safeMintRange(collection, msg.sender, msg.sender, start, end);
+    minter.safeMintRange(collection, msg.sender, start, end);
   }
 
   function callTransferCollection(address collection, address nextOwner) public {
@@ -49,17 +48,25 @@ contract MinterTest is Test, ERC721Holder {
     balot.transferOwnership(address(minter));
 
     address collection = address(balot);
-    address nextOwner = address(this);
     address to = address(1337);
     uint16 start = 1;
     uint16 end = 300;
 
     minter.safeMintRange(
       collection,
-      nextOwner,
       to,
       start,
       end
+    );
+  }
+
+  function testUnauthorizedTransferCollection() public {
+    balot.transferOwnership(address(minter));
+    address nextOwner = address(this);
+
+    vm.expectRevert();
+    mc.callTransferCollection(
+      address(balot), nextOwner
     );
   }
 
@@ -87,14 +94,12 @@ contract MinterTest is Test, ERC721Holder {
     vm.expectRevert(bytes("ERC721: owner query for nonexistent token"));
     balot.ownerOf(1);
     address collection = address(balot);
-    address nextOwner = address(this);
     address to = address(1337);
     uint16 start = 1;
     uint16 end = 300;
 
     minter.safeMintRange(
       collection,
-      nextOwner,
       to,
       start,
       end
@@ -107,24 +112,12 @@ contract MinterTest is Test, ERC721Holder {
     assertEq(balot.tokenURI(300), string(abi.encodePacked(baseURI, "300.json")));
     vm.expectRevert(bytes("ERC721URIStorage: URI query for nonexistent token"));
     balot.tokenURI(301);
-
-    assertEq(balot.owner(), address(nextOwner));
   }
 
   function testTransferCollection() public {
     balot.transferOwnership(address(minter));
     minter.transferCollection(address(balot), address(this));
-    
+
     assertEq(balot.owner(), address(this));
-  }
-
-  function testUnauthorizedTransferCollection() public {
-    balot.transferOwnership(address(minter));
-    address nextOwner = address(this);
-
-    vm.expectRevert();
-    mc.callTransferCollection(
-      address(balot), nextOwner
-    );
   }
 }

--- a/test/testMinter.ts
+++ b/test/testMinter.ts
@@ -35,11 +35,10 @@ describe("Balot", async () => {
   describe("Minter.safeMintRange in order", async () => {
     let minter: Contract,
       minterOwner: SignerWithAddress,
-      nextOwner: SignerWithAddress,
       recipient: SignerWithAddress;
 
     beforeEach(async () => {
-      [, minterOwner, nextOwner, recipient] = await ethers.getSigners();
+      [, minterOwner, recipient] = await ethers.getSigners();
 
       const Minter = await ethers.getContractFactory("Minter", minterOwner);
 
@@ -52,17 +51,7 @@ describe("Balot", async () => {
       const start = 1,
         end = 300;
       // 3. Range mint + transfer Balot ownership
-      await minter.safeMintRange(
-        balot.address,
-        nextOwner.address,
-        recipient.address,
-        start,
-        end
-      );
-    });
-
-    it("should transfer ownership", async () => {
-      expect(await balot.owner()).to.be.equal(nextOwner.address);
+      await minter.safeMintRange(balot.address, recipient.address, start, end);
     });
   });
 
@@ -70,19 +59,17 @@ describe("Balot", async () => {
     let minter: Contract,
       minterOwner: SignerWithAddress,
       attacker: SignerWithAddress,
-      attackerNextOwner: SignerWithAddress,
       attackerRecipient: SignerWithAddress;
 
     beforeEach(async () => {
-      [, minterOwner, attacker, attackerNextOwner, attackerRecipient] =
-        await ethers.getSigners();
+      [, minterOwner, attacker, attackerRecipient] = await ethers.getSigners();
 
       const Minter = await ethers.getContractFactory("Minter", minterOwner);
 
       // 1. Deploy Minter
       minter = await Minter.deploy();
 
-      // 2. Tranfer Balot ownership to minter
+      // 2. Transfer Balot ownership to minter
       await balot.transferOwnership(minter.address);
     });
 
@@ -94,7 +81,6 @@ describe("Balot", async () => {
       await expect(
         attackedMinter.safeMintRange(
           balot.address,
-          attackerNextOwner.address,
           attackerRecipient.address,
           start,
           end
@@ -106,11 +92,10 @@ describe("Balot", async () => {
   describe("Failing Minter.safeMintRange", async () => {
     let minter: Contract,
       minterOwner: SignerWithAddress,
-      nextOwner: SignerWithAddress,
       recipient: SignerWithAddress;
 
     beforeEach(async () => {
-      [, minterOwner, nextOwner, recipient] = await ethers.getSigners();
+      [, minterOwner, recipient] = await ethers.getSigners();
 
       const Minter = await ethers.getContractFactory("Minter", minterOwner);
 
@@ -124,13 +109,7 @@ describe("Balot", async () => {
         end = 9999;
       // 3. Range mint + transfer Balot ownership
       await expect(
-        minter.safeMintRange(
-          balot.address,
-          nextOwner.address,
-          recipient.address,
-          start,
-          end
-        )
+        minter.safeMintRange(balot.address, recipient.address, start, end)
       ).to.be.revertedWith(
         "Transaction reverted: contract call run out of gas and made the transaction revert"
       );

--- a/test/testScenarios.ts
+++ b/test/testScenarios.ts
@@ -57,7 +57,7 @@ describe("All good scenario", async function () {
     });
   });
 
-  it("Step 1/3: deploy minter", async () => {
+  it("Step 1/4: deploy minter", async () => {
     [minterOwner] = await ethers.getSigners();
 
     const Minter = await ethers.getContractFactory("Minter", minterOwner);
@@ -71,7 +71,7 @@ describe("All good scenario", async function () {
     return;
   });
 
-  it("Step 2/3: transfer Balot ownership", async () => {
+  it("Step 2/4: transfer Balot ownership", async () => {
     const safeSigner = await ethers.getSigner(ADDRESSES.safe);
     balotFromSafe = new ethers.Contract(ADDRESSES.balot, BALOT_ABI, safeSigner);
 
@@ -87,7 +87,7 @@ describe("All good scenario", async function () {
     return;
   });
 
-  it("Step 3/3: safe mint range", async () => {
+  it("Step 3/4: safe mint range", async () => {
     const safeMintRangeTx = await minter.safeMintRange(
       ADDRESSES.balot,
       ADDRESSES.safe,
@@ -102,6 +102,23 @@ describe("All good scenario", async function () {
 
     console.debug(
       `SafeMintRange gas used: ${(await safeMintRangeTx.wait()).gasUsed}`
+    );
+    return;
+  });
+  it("Step 4/4: transfer Balot ownership back to Safe", async () => {
+    const transferCollectionTx = await minter.transferCollection(
+      ADDRESSES.balot,
+      ADDRESSES.safe
+    );
+
+    expect((await balotFromSafe.owner()).toUpperCase()).to.equal(
+      ADDRESSES.safe.toUpperCase()
+    );
+
+    console.debug(
+      `transferCollection gas used: ${
+        (await transferCollectionTx.wait()).gasUsed
+      }`
     );
     return;
   });

--- a/test/testScenarios.ts
+++ b/test/testScenarios.ts
@@ -91,7 +91,6 @@ describe("All good scenario", async function () {
     const safeMintRangeTx = await minter.safeMintRange(
       ADDRESSES.balot,
       ADDRESSES.safe,
-      ADDRESSES.safe,
       1,
       300
     );
@@ -100,9 +99,6 @@ describe("All good scenario", async function () {
       await balotFromSafe.balanceOf(ADDRESSES.safe)
     );
     expect(newSafeBalance).to.equal(initialSafeBalance + 300);
-    expect((await balotFromSafe.owner()).toUpperCase()).to.equal(
-      ADDRESSES.safe.toUpperCase()
-    );
 
     console.debug(
       `SafeMintRange gas used: ${(await safeMintRangeTx.wait()).gasUsed}`
@@ -173,13 +169,7 @@ describe("Failing mint & reverting scenario", async function () {
   });
   it("Step 3/4: safe mint range FAILED", async () => {
     return await expect(
-      minter.safeMintRange(
-        ADDRESSES.balot,
-        ADDRESSES.safe,
-        ADDRESSES.safe,
-        1,
-        1000
-      )
+      minter.safeMintRange(ADDRESSES.balot, ADDRESSES.safe, 1, 1000)
     ).to.be.revertedWith(
       "Transaction reverted: contract call run out of gas and made the transaction revert"
     );


### PR DESCRIPTION
- the reason to remove 'transferOwnership` from `safeMintRange` is that we may need to mint in segments of e.g. 100 NFTs, and so transferring the ownership would be annoying. So it's better to split these two operations entirely.
- Fixes #42