### PR TITLE
Pin node and npm minor versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,8 +32,8 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
-          cache: "npm"
+          node-version: "16.15.0"
+          cache: npm
 
       - name: Install HartHat
         run: npm ci --dev

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,10 @@
         "ts-node": "^10.8.0",
         "typechain": "8.0.0",
         "typescript": "^4.7.2"
+      },
+      "engines": {
+        "node": "~16.13.0",
+        "npm": "~8.3.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "engines": {
+    "node": "~16.15.0",
+    "npm" : "^8.5.0"
+  },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "2.0.6",
     "@nomiclabs/hardhat-waffle": "2.0.3",


### PR DESCRIPTION
Fix #45 

`~` pins down `node` to minor, which brings more reliability than major version.